### PR TITLE
Security update to libgnutls30

### DIFF
--- a/zulu-11/Dockerfile
+++ b/zulu-11/Dockerfile
@@ -7,8 +7,9 @@ RUN cd dumb-init && make
 FROM docker.io/azul/zulu-openjdk-debian:11.0.7-11.39.15
 COPY --from=dumb-init-builder /dumb-init/dumb-init /usr/local/bin/dumb-init
 
-#RUN apt-get update && \
-#    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \
-                     # These packages are security updates
+RUN apt-get update && \
+   DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \
+       # These packages are security updates
+       libgnutls30=3.6.7-4+deb10u4         
 
 ENTRYPOINT ["/usr/local/bin/dumb-init"]


### PR DESCRIPTION
per https://security-tracker.debian.org/tracker/CVE-2020-13777 (BDSA-2020-1303)